### PR TITLE
[Feature] Add command-line argument handling to ecobat.pl

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,20 @@ EcoBat is a Perl script designed to capture network packets and identify potenti
 
 ## Prerequisites
 - Perl installed on your system
-- Required Perl modules: Net::PcapUtils, NetPacket::Ethernet, NetPacket::IP, NetPacket::TCP, Data::HexDump, Net::Traceroute
+- Required Perl modules: `Net::PcapUtils`, `NetPacket::Ethernet`, `NetPacket::IP`, `NetPacket::TCP`, `Data::HexDump`, `Net::Traceroute`.
 
 ## Usage
 1. Clone the repository to your local machine:
 
+```bash
 git clone <repository-url>
-
-
-
+```
 
 2. Navigate to the directory containing the script:
 
+```bash
 cd EcoBat
-
-
-
+```
 
 3. Ensure that Perl and the required Perl modules are installed on your system. If not, install them using your system's package manager or CPAN.
 
@@ -28,10 +26,9 @@ cd EcoBat
 
 5. Run the script:
 
+```bash
 ./ecobat.pl
-
-
-
+```
 
 6. The script will start capturing packets on the specified IP address. It will log packet details to `pacotes.log` and perform a traceroute to the IP address that generates the most traffic, saving the result to a log file named `<most_common_ip>-traceroute.log`.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ cd EcoBat
 5. Run the script:
 
 ```bash
-./ecobat.pl
+./ecobat.pl <ip_address>
+```
+
+Example:
+```bash
+./ecobat.pl 192.168.0.1
 ```
 
 6. The script will start capturing packets on the specified IP address. It will log packet details to `pacotes.log` and perform a traceroute to the IP address that generates the most traffic, saving the result to a log file named `<most_common_ip>-traceroute.log`.

--- a/ecobat.pl
+++ b/ecobat.pl
@@ -63,8 +63,6 @@ sub process_pkt {
 }
 
 sub main {
-    my $ip_address = '192.168.113.86'; #Change the target
-
     my $desenho = '
     ....._      
     `.   ``-.                               .-----.._
@@ -97,6 +95,12 @@ sub main {
     print $desenho;
     print $title;
 
+    # Check if an IP address was provided as an argument
+    if (@ARGV != 1) {
+        die "Usage: $0 <ip_address>\n";
+    }
+
+    my $ip_address = $ARGV[0];
     sniff($ip_address);
 }
 


### PR DESCRIPTION
# Description
This pull request introduces the ability to pass an IP address as a command-line argument when running the ecobat.pl script. This change makes the script more flexible and easier to use, as users can now analyze network traffic for different IP addresses without having to modify the script itself.

## Changes
1. Updated the main() function to check if an IP address was provided as an argument. If not, it displays a usage message.
2. Replaced the hardcoded IP address in the sniff() function with the user-provided argument.
3. Added code formatting and new instructions to README.md.

## Potential Impact
This change should not have any adverse impact on the existing functionality of the ecobat.pl script. It simply adds a new feature that enhances the usability of the tool.
